### PR TITLE
删除README当中配置的重复字段

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,9 +330,6 @@ A best practice for VSCode is to auto format code with Prettier and autofix erro
 {
   "files.eol": "\n",
   "editor.tabSize": 2,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.validate": ["javascript", "javascriptreact", "vue", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -356,9 +356,6 @@ VSCode 的一个最佳实践就是通过配置 `.vscode/settings.json` 来支持
 {
   "files.eol": "\n",
   "editor.tabSize": 2,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.validate": ["javascript", "javascriptreact", "vue", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {


### PR DESCRIPTION
删除README中配置的重复字段
~~~
  "editor.codeActionsOnSave": {
    "source.fixAll.eslint": true
  },
~~~
出现了两次。